### PR TITLE
Move coder and behat from scaffold to require-dev.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,8 @@
         "phpunit/phpunit": "6.5",
         "behat/behat": "^3.5",
         "behat/gherkin": "^4.5",
+        "drupal/coder": "^8.3",
+        "drupal/drupal-extension": "3.4.1",
         "drupal/schema_metatag": "^1.4",
         "jakub-onderka/php-parallel-lint": "^1.0",
         "integratedexperts/behat-screenshot": "^0.7.2"


### PR DESCRIPTION
Couple of tools in the wrong sections. This should go into develop branch when it gets created.

Goes in with https://github.com/govCMS/scaffold-tooling/pull/20