### PR TITLE
Remove drupal/schema_metatag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
         "phpunit/phpunit": "6.5",
         "behat/behat": "^3.5",
         "behat/gherkin": "^4.5",
-        "drupal/schema_metatag": "^1.4",
         "jakub-onderka/php-parallel-lint": "^1.0",
         "integratedexperts/behat-screenshot": "^0.7.2"
     }


### PR DESCRIPTION
This module came from collecting requirements across projects, but is not needed.